### PR TITLE
Bugfix and added weight init from file (other than download it)

### DIFF
--- a/ubo_smad_r3.py
+++ b/ubo_smad_r3.py
@@ -6,7 +6,7 @@ from facenet_pytorch import MTCNN, InceptionResnetV1
 
 
 WEIGHTS_URL = "https://miatbiolab.csr.unibo.it/wp-content/uploads/2023/inception-resnet-smad-4a96dd25.ckpt"
-WEIGHTS_FILE = "./weights/inception-resnet-smad-4a96dd25.ckpt"
+WEIGHTS_FILE = Path(__file__).parent / "weights" / "inception-resnet-smad-4a96dd25.ckpt"
 
 def _crop_face(image_rgb: np.ndarray, mtcnn: MTCNN) -> np.ndarray:
     boxes, _ = mtcnn.detect(image_rgb)
@@ -72,9 +72,9 @@ def get_prediction(
         document_bgr = [document_bgr]
     # Download the Siamese weights or load them from file
     if Path(WEIGHTS_FILE).exists():
-        state_dict = torch.load(WEIGHTS_FILE)
+        state_dict = torch.load(WEIGHTS_FILE, weights_only=True)
     else:
-        state_dict = torch.hub.load_state_dict_from_url(WEIGHTS_URL, map_location="cpu", check_hash=True)
+        state_dict = torch.hub.load_state_dict_from_url(WEIGHTS_URL, map_location="cpu", check_hash=True, weights_only=True)
     # Load the SMAD classifier
     smad = InceptionResnetV1(
         pretrained=None,


### PR DESCRIPTION
I added the ability to load weights from file (in addition to via download as previously implemented). Also fixed an error in the return statement of get_predictions(): in the case of single prediction, the outgoing probability was of type float (which does not have a ```__len__()``` method, resulting in a program exception). I then operated a cast to list when necessary